### PR TITLE
FLEXSIM-10931 Fixed Grid update script exception

### DIFF
--- a/AStar.fsx
+++ b/AStar.fsx
@@ -7121,7 +7121,7 @@ if (!nav)
 	return 0;
 
 treenode grids = getvarnode(nav, "grids");
-if (grids.first.dataType == DATATYPE_COUPLING)
+if (!grids.first || grids.first.dataType == DATATYPE_COUPLING){
 	return 0; // If coming from older than 19.0, a grid might have already been asserted by an earlier update script
 
 treenode oldGrids = assertvariable(nav, "oldGrids");


### PR DESCRIPTION
Having no barriers in a model older than 19.0 caused the grids treenode to be present, but empty on update. We want to exit the update script if grids has no subnodes.