### PR TITLE
Fixed repeatability issue

### DIFF
--- a/AStarDLL/AStarTypes.cpp
+++ b/AStarDLL/AStarTypes.cpp
@@ -768,8 +768,12 @@ void TravelPath::update(Traveler* traveler, double atDist)
 						}
 						double maxTurnAngle = boundAngle(toAngle - fromAngle);
 						double startTime = fromEntry.arrivalTime;
-						double turnAngle = sign(maxTurnAngle) * turnSpeed * (time() - startTime);
-						updateZRot = fromAngle + turnAngle;
+						double turnDist = turnSpeed * (time() - startTime);
+						if (turnDist <= 0.0)
+							updateZRot = fromAngle;
+						else if (turnDist < fabs(maxTurnAngle))
+							updateZRot = fromAngle + sign(maxTurnAngle) * turnDist;
+						else updateZRot = toAngle;
 					}
 					else updateZRot = toAngle;
 				}


### PR DESCRIPTION
The problem was that the toEntry.turnEndTime is technically set to the time that the to-next cell movement starts, meaning there may be a gap where the code gets into this if statement after the object has finished rotating to the destination direction. So the object may over-rotate. So I just put bounds on the rotation. If the turnDist is less than 0 (shouldn't be but just to make sure) it will set it to the fromAngle, if the turnDist is positive but less than the max turn dist, set it to the resolved rotation, and otherwise set it to toAngle.