### PR TITLE
[FLEXSIM-11344] Fixed AStar* grid throwing exceptions

### DIFF
--- a/AStarDLL/Grid.cpp
+++ b/AStarDLL/Grid.cpp
@@ -1498,7 +1498,14 @@ void Grid::makeDirty()
 
 double Grid::onDestroy(treenode view)
 {
-	if (holder->up->subnodes.length == 1) {
+	if (!holder || !holder->up)
+		return 1.0;
+
+	AStarNavigator* nav = holder->up->objectAs(AStarNavigator);
+	if (!nav)
+		return 1.0;
+
+	if (nav->grids.length == 1) {
 		msg("Grid Deletion Not Allowed", "You cannot delete all A* grids.", 1);
 		return 1.0;
 	}


### PR DESCRIPTION
* The onDestroy event of the grid was only checking the AStarNavigator's subnodes rather than the grids array. I changed it to check the grids array instead.
* Also added a few nullptr checks for safety.