### PR TITLE
FLEXSIM-6717 - Add "Reverse Path" button for A* paths

### DIFF
--- a/AStar.fsx
+++ b/AStar.fsx
@@ -5983,6 +5983,7 @@ for (int i = 1; i &lt;= n; i++) {
 	treenode point = pointsNode.subnodes[i];
 	createundorecord(c, point, UNDO_CHANGE_RANK, n - i + 1);
 }
+beginignoreundo();
 int left = 0;
 int right = n - 1;
 while (left &lt; right) {
@@ -5990,11 +5991,12 @@ while (left &lt; right) {
 	left += 1;
 	right -= 1;
 }
+endignoreundo();
 endaggregatedundo(c, undoId);
 
 applylinks(table, 1);
 refreshview(table);
-function_s(barrier, "setActiveIndex", pointsNode.subnodes.length - 1);
+function_s(barrier, "setActiveIndex", n - 1);
 barrier.applyProperties("PathPoints");
 function_s(Model.find("AStarNavigator"), "rebuildMeshes");
 repaintall();</data>

--- a/AStar.fsx
+++ b/AStar.fsx
@@ -5976,29 +5976,33 @@ if (propertiesView) {
         <node f="42" dt="2"><name>OnPress</name><data>treenode table = node("../PointsEdit/PointsTable", c);
 Object barrier = node("..&gt;objectfocus+", c);
 treenode pointsNode = node("&gt;variables/points", barrier);
+int n = pointsNode.subnodes.length;
 
-int undoId = beginaggregatedundo(c.up, "Reverse Points");
+int undoId = beginaggregatedundo(c, "Reverse Points");
+for (int i = 1; i &lt;= n; i++) {
+	treenode point = pointsNode.subnodes[i];
+	createundorecord(c, point, UNDO_CHANGE_RANK, n - i + 1);
+}
 int left = 0;
-int right = table.find("&gt;viewfocus+").subnodes.length - 1;
+int right = n - 1;
 while (left &lt; right) {
 	function_s(barrier, "swapPoints", left, right);
 	left += 1;
 	right -= 1;
 }
-endaggregatedundo(c.up, undoId);
+endaggregatedundo(c, undoId);
+
 applylinks(table, 1);
 refreshview(table);
-function_s(barrier, "setActiveIndex", 0);
+function_s(barrier, "setActiveIndex", pointsNode.subnodes.length - 1);
 barrier.applyProperties("PathPoints");
 function_s(Model.find("AStarNavigator"), "rebuildMeshes");
-repaintall();
-settableviewselection(table, 1, 1, 1, 3);
-repaintview(table);</data>
+repaintall();</data>
          <node f="40"><name></name></node></node>
-        <node f="4000000042" dt="2"><name>tooltip</name><data>Reverse the points in the list</data></node>
+        <node f="4000000042" dt="2"><name>tooltip</name><data>Reverse the direction</data></node>
         <node f="42" dt="2"><name>bitmap</name><data>buttons\swap.png</data></node>
         <node f="42" dt="1"><name>beveltype</name><data>0000000040080000</data></node>
-        <node f="42" dt="2"><name>undohistory</name><data>..</data></node>
+        <node f="42" dt="2"><name>undohistory</name><data>../..</data></node>
        </data>
         <node f="40"><name></name></node></node>
        <node f="42" dt="4"><name>PointsEdit</name><data>

--- a/AStar.fsx
+++ b/AStar.fsx
@@ -5979,19 +5979,12 @@ treenode pointsNode = node("&gt;variables/points", barrier);
 int n = pointsNode.subnodes.length;
 
 int undoId = beginaggregatedundo(c, "Reverse Points");
-for (int i = 1; i &lt;= n; i++) {
-	treenode point = pointsNode.subnodes[i];
-	createundorecord(c, point, UNDO_CHANGE_RANK, n - i + 1);
+for (int i = 1; i &lt;= n / 2; i++) {
+	int oppositeIndex = n - i + 1;
+	treenode oppositeNode = pointsNode.subnodes[oppositeIndex];
+	pointsNode.subnodes[i].rank = oppositeIndex;
+	oppositeNode.rank = i;
 }
-beginignoreundo();
-int left = 0;
-int right = n - 1;
-while (left &lt; right) {
-	function_s(barrier, "swapPoints", left, right);
-	left += 1;
-	right -= 1;
-}
-endignoreundo();
 endaggregatedundo(c, undoId);
 
 applylinks(table, 1);

--- a/AStar.fsx
+++ b/AStar.fsx
@@ -5965,6 +5965,42 @@ if (propertiesView) {
         <node f="4000000042" dt="2"><name>tooltip</name><data>Tells if the object's rule applies both ways</data></node>
         <node f="4000000042" dt="2"><name>windowtitle</name><data>Two Way</data></node>
        </data></node>
+       <node f="42" dt="4"><name>Reverse</name><data>
+        <node f="40"><name>object</name></node>
+        <node f="42" dt="1"><name>viewwindowtype</name><data>0000000040590000</data></node>
+        <node f="42" dt="1"><name>spatialx</name><data>0000000000000000</data></node>
+        <node f="42" dt="1"><name>spatialy</name><data>0000000040490000</data></node>
+        <node f="42" dt="1"><name>spatialsx</name><data>00000000403d0000</data></node>
+        <node f="42" dt="1"><name>spatialsy</name><data>0000000040350000</data></node>
+        <node f="42" dt="1"><name>alignrightposition</name><data>0000000040410000</data></node>
+        <node f="42" dt="2"><name>OnPress</name><data>treenode table = node("../PointsEdit/PointsTable", c);
+Object barrier = node("..&gt;objectfocus+", c);
+treenode pointsNode = node("&gt;variables/points", barrier);
+
+int undoId = beginaggregatedundo(c.up, "Reverse Points");
+int left = 0;
+int right = table.find("&gt;viewfocus+").subnodes.length - 1;
+while (left &lt; right) {
+	function_s(barrier, "swapPoints", left, right);
+	left += 1;
+	right -= 1;
+}
+endaggregatedundo(c.up, undoId);
+applylinks(table, 1);
+refreshview(table);
+function_s(barrier, "setActiveIndex", 0);
+barrier.applyProperties("PathPoints");
+function_s(Model.find("AStarNavigator"), "rebuildMeshes");
+repaintall();
+settableviewselection(table, 1, 1, 1, 3);
+repaintview(table);</data>
+         <node f="40"><name></name></node></node>
+        <node f="4000000042" dt="2"><name>tooltip</name><data>Reverse the points in the list</data></node>
+        <node f="42" dt="2"><name>bitmap</name><data>buttons\swap.png</data></node>
+        <node f="42" dt="1"><name>beveltype</name><data>0000000040080000</data></node>
+        <node f="42" dt="2"><name>undohistory</name><data>..</data></node>
+       </data>
+        <node f="40"><name></name></node></node>
        <node f="42" dt="4"><name>PointsEdit</name><data>
         <node f="40"><name>object</name></node>
         <node f="42" dt="1"><name>viewwindowtype</name><data>0000000040598000</data></node>
@@ -6139,41 +6175,6 @@ repaintview(table);</data></node>
          <node f="42" dt="1"><name>beveltype</name><data>0000000040080000</data></node>
          <node f="42" dt="2"><name>undohistory</name><data>../..</data></node>
         </data></node>
-        <node f="42" dt="4"><name>Reverse</name><data>
-         <node f="40"><name>object</name></node>
-         <node f="42" dt="1"><name>viewwindowtype</name><data>0000000040590000</data></node>
-         <node f="42" dt="1"><name>spatialx</name><data>00000000405d0000</data></node>
-         <node f="42" dt="1"><name>spatialy</name><data>0000000040320000</data></node>
-         <node f="42" dt="1"><name>spatialsx</name><data>00000000403d0000</data></node>
-         <node f="42" dt="1"><name>spatialsy</name><data>0000000040350000</data></node>
-         <node f="42" dt="2"><name>OnPress</name><data>treenode table = node("../PointsTable", c);
-Object barrier = node("../..&gt;objectfocus+", c);
-treenode pointsNode = node("&gt;variables/points", barrier);
-
-int undoId = beginaggregatedundo(c, "Reverse Points");
-int left = 0;
-int right = content(node("&gt;viewfocus+", table)) - 1;
-while (left &lt; right) {
-	function_s(barrier, "swapPoints", left, right);
-	left += 1;
-	right -= 1;
-}
-endaggregatedundo(c, undoId);
-applylinks(table, 1);
-refreshview(table);
-function_s(barrier, "setActiveIndex", content(pointsNode) -1);
-barrier.applyProperties("PathPoints");
-function_s(Model.find("AStarNavigator"), "rebuildMeshes");
-repaintall();
-settableviewselection(table, 1, 0, 1, 2);
-repaintview(table);</data>
-          <node f="40"><name></name></node></node>
-         <node f="4000000042" dt="2"><name>tooltip</name><data>Reverse the points in the list</data></node>
-         <node f="42" dt="2"><name>bitmap</name><data>buttons\swap.png</data></node>
-         <node f="42" dt="1"><name>beveltype</name><data>0000000040080000</data></node>
-         <node f="42" dt="2"><name>undohistory</name><data>../..</data></node>
-        </data>
-         <node f="40"><name></name></node></node>
         <node f="42" dt="4"><name>PointsTable</name><data>
          <node f="40"><name>object</name></node>
          <node f="42" dt="2"><name>viewfocus</name><data>..&gt;table</data></node>

--- a/AStar.fsx
+++ b/AStar.fsx
@@ -6139,6 +6139,41 @@ repaintview(table);</data></node>
          <node f="42" dt="1"><name>beveltype</name><data>0000000040080000</data></node>
          <node f="42" dt="2"><name>undohistory</name><data>../..</data></node>
         </data></node>
+        <node f="42" dt="4"><name>Reverse</name><data>
+         <node f="40"><name>object</name></node>
+         <node f="42" dt="1"><name>viewwindowtype</name><data>0000000040590000</data></node>
+         <node f="42" dt="1"><name>spatialx</name><data>00000000405d0000</data></node>
+         <node f="42" dt="1"><name>spatialy</name><data>0000000040320000</data></node>
+         <node f="42" dt="1"><name>spatialsx</name><data>00000000403d0000</data></node>
+         <node f="42" dt="1"><name>spatialsy</name><data>0000000040350000</data></node>
+         <node f="42" dt="2"><name>OnPress</name><data>treenode table = node("../PointsTable", c);
+Object barrier = node("../..&gt;objectfocus+", c);
+treenode pointsNode = node("&gt;variables/points", barrier);
+
+int undoId = beginaggregatedundo(c, "Reverse Points");
+int left = 0;
+int right = content(node("&gt;viewfocus+", table)) - 1;
+while (left &lt; right) {
+	function_s(barrier, "swapPoints", left, right);
+	left += 1;
+	right -= 1;
+}
+endaggregatedundo(c, undoId);
+applylinks(table, 1);
+refreshview(table);
+function_s(barrier, "setActiveIndex", content(pointsNode) -1);
+barrier.applyProperties("PathPoints");
+function_s(Model.find("AStarNavigator"), "rebuildMeshes");
+repaintall();
+settableviewselection(table, 1, 0, 1, 2);
+repaintview(table);</data>
+          <node f="40"><name></name></node></node>
+         <node f="4000000042" dt="2"><name>tooltip</name><data>Reverse the points in the list</data></node>
+         <node f="42" dt="2"><name>bitmap</name><data>buttons\swap.png</data></node>
+         <node f="42" dt="1"><name>beveltype</name><data>0000000040080000</data></node>
+         <node f="42" dt="2"><name>undohistory</name><data>../..</data></node>
+        </data>
+         <node f="40"><name></name></node></node>
         <node f="42" dt="4"><name>PointsTable</name><data>
          <node f="40"><name>object</name></node>
          <node f="42" dt="2"><name>viewfocus</name><data>..&gt;table</data></node>

--- a/AStar.fsx
+++ b/AStar.fsx
@@ -5979,12 +5979,11 @@ treenode pointsNode = node("&gt;variables/points", barrier);
 int n = pointsNode.subnodes.length;
 
 int undoId = beginaggregatedundo(c, "Reverse Points");
-for (int i = 1; i &lt;= n / 2; i++) {
-	int oppositeIndex = n - i + 1;
-	treenode oppositeNode = pointsNode.subnodes[oppositeIndex];
-	pointsNode.subnodes[i].rank = oppositeIndex;
-	oppositeNode.rank = i;
+for (int i = 1; i &lt;= n; i++) {
+	treenode point = pointsNode.subnodes[i];
+	createundorecord(c, point, UNDO_CHANGE_RANK, n - i + 1);
 }
+function_s(barrier, "reversePoints");
 endaggregatedundo(c, undoId);
 
 applylinks(table, 1);

--- a/AStarDLL/Barrier.cpp
+++ b/AStarDLL/Barrier.cpp
@@ -37,6 +37,7 @@ void Barrier::bind(void)
 	bindCallback(addPoint, Barrier);
 	bindCallback(removePoint, Barrier);
 	bindCallback(swapPoints, Barrier);
+	bindCallback(reversePoints, Barrier);
 	bindCallback(getPointCoord, Barrier);
 	bindCallback(setPointCoords, Barrier);
 	bindCallback(getType, Barrier);
@@ -1002,6 +1003,13 @@ void Barrier::swapPoints(int index1, int index2)
 		return;
 
 	pointList.swap(index1, index2);
+}
+
+void Barrier::reversePoints()
+{
+	int n = pointList.size();
+	for (int i = 0; i < n / 2; ++i)
+		pointList.swap(i, n - i - 1);
 }
 
 Vec3 Barrier::getLocalPointCoords(int pointIndex)

--- a/AStarDLL/Barrier.h
+++ b/AStarDLL/Barrier.h
@@ -172,6 +172,8 @@ public:
 	astar_export Variant removePoint(FLEXSIMINTERFACE) { removePoint((int)param(1));  return Variant(); }
 	void swapPoints(int index1, int index2);
 	astar_export Variant swapPoints(FLEXSIMINTERFACE) { swapPoints((int)param(1), (int)param(2)); return Variant(); }
+	void reversePoints();
+	astar_export Variant reversePoints(FLEXSIMINTERFACE) { reversePoints(); return Variant(); }
 	Vec3 getLocalPointCoords(int pointIndex);
 	Vec3 getPointCoords(int pointIndex);
 	astar_export Variant getPointCoord(FLEXSIMINTERFACE);


### PR DESCRIPTION
This PR introduces a new **"Reverse Path"** button for A* paths. The purpose of this enhancement is to provide users with a convenient way to quickly invert an existing A* path, eliminating the need to manually recreate the same path in the opposite direction.

With this feature, users can:
- Reverse the direction of an A* path with a single action.
- Save modeling time when testing or implementing bidirectional flow.
- Reduce errors caused by manually redrawing paths.