### PR TITLE
Fixed issue with looping same-time event when re-allocating allocated CA

### DIFF
--- a/AStarDLL/AStarNavigator.cpp
+++ b/AStarDLL/AStarNavigator.cpp
@@ -651,6 +651,7 @@ double AStarNavigator::navigateToLoc(Traveler* traveler, double* destLoc, double
 		// next cell in his path
 		auto atDist = traveler->updateLocation(true);
 		int atIndex = traveler->travelPath.updateAtIndex(atDist);
+		traveler->updateSpeedMarkers();
 		TravelPath::iterator originIter = traveler->travelPath.begin() + atIndex;
 		bool shouldChangeLoc = originIter->atTravelDist - atDist > traveler->tinyDist;
 		if (shouldChangeLoc) {
@@ -2262,8 +2263,8 @@ void AStarNavigator::buildControlAreaSets()
 		auto obj = controlAreas[i];
 		controlAreaMap[obj] = i;
 		auto bb = obj->getAxisAlignedBoundingBox(model());
-		for (auto x = bb.min.x; x <= bb.max.x; x += minNodeSize.x) {
-			for (auto y = bb.min.y; y <= bb.max.y; y += minNodeSize.y) {
+		for (auto x = bb.min.x - 0.5 * minNodeSize.x; x <= bb.max.x + 0.5 * minNodeSize.x; x += minNodeSize.x) {
+			for (auto y = bb.min.y - 0.5 * minNodeSize.y; y <= bb.max.y + 0.5 * minNodeSize.x; y += minNodeSize.y) {
 				Vec3 pos(x, y, bb.min.z);
 				auto cell = getCell(pos); 
 				Vec3 localPos = getLocation(cell).project(model(), obj->holder);


### PR DESCRIPTION
- When you end with non-zero speed, the object finishes the task before arriving at the destination, so that it can still decelerate to a stop given its deceleration. If you then give it another task going a different direction, the path it builds may exit and area and then almost-immediately re-enter that control area. Because of the time of allocation when deceleration is involved, it may occur that the time for re-allocation of the control area happens BEFORE the release of the control area from when you originally exited it. This was not taken into account in the allocation timing algorithm. So, in the final step before creation of the allocation event, I need to do one last check to see 'have I already allocated this object, and if so, will the deallocation of that object happen AFTER the time I need to re-allocate it. If so, then I should not even reallocate, but just keep the allocation.
- I also realized that the math for determining which node were inside a control area was missing one or the other edge of the control area, so I extended the search a little bit.
- I also was noticing object 'jump' between tasks. This is because the logic was reading the start speed as 0 when it shouldn't be. The task executer logic sets lastspeedupdatetime and lastupdatedspeed at the beginning of a TRAVEL task. I want to override that so it will read a current speed of non-zero. So I call updateSpeedMarkers() at the beginning of navigateToLoc().