### PR TITLE
Switch native projects to Visual Studio 2026 (v145)

### DIFF
--- a/AStarDLL/AStar.sln
+++ b/AStarDLL/AStar.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.2.32630.192
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11626.88
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AStar", "AStar.vcxproj", "{340EB70E-DFC3-405D-B723-4C9BE0977380}"
 EndProject

--- a/AStarDLL/AStar.vcxproj
+++ b/AStarDLL/AStar.vcxproj
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)..\</OutDir>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <LinkIncremental>true</LinkIncremental>

--- a/AStarInstaller.sln
+++ b/AStarInstaller.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.2.32630.192
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11626.88
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "AStarInstaller", "AStarInstaller.wixproj", "{57165A50-7945-4300-BEFA-D43603A22095}"
 EndProject


### PR DESCRIPTION
## Summary
Moves **AStar** (DLL and installer solution) to **Visual Studio 2026**: **Platform Toolset v145** and VS **18** solution format.

## Changes
- **`AStarDLL/AStar.vcxproj`**: `PlatformToolset` → **v145**.
- **`AStarDLL/AStar.sln`** and **`AStarInstaller.sln`**: solution format updated for Visual Studio 18.

**Base:** `release/27.0` · **Branch:** `jjordanl/switch-to-vs-2026`