### PR TITLE
FLEXSIM-12564: Fix PreferredPath to avoid modifying grid passability

### DIFF
--- a/AStarDLL/PreferredPath.cpp
+++ b/AStarDLL/PreferredPath.cpp
@@ -61,9 +61,8 @@ void PreferredPath::addPassagesToTable(Grid* grid)
 		int horizontalWeight = (int)(weight * 127 * dx / (fabs(dx) + fabs(dy)));
 		int verticalWeight = (int)(weight * 127 * dy / (fabs(dx) + fabs(dy)));
 
-		std::vector<Cell> segmentCells;
-
-		grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight, &segmentCells](const Cell& cell) -> void {
+		Cell prevCell(0, (unsigned short)Cell::INVALID_ROW, 0);
+		grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight, &prevCell](const Cell& cell) -> void {
 			AStarNode* node = grid->getNode(cell);
 			AStarNodeExtraData * extra = grid->navigator->assertExtraData(cell, PreferredPathData);
 			node->hasPreferredPathWeight = true;
@@ -80,7 +79,33 @@ void PreferredPath::addPassagesToTable(Grid* grid)
 				extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown + fabs(verticalWeight)));
 			}
 
-			segmentCells.push_back(cell);
+			if (prevCell.row != (unsigned short)Cell::INVALID_ROW) {
+				int stepDx = (int)cell.col - (int)prevCell.col;
+				int stepDy = (int)cell.row - (int)prevCell.row;
+				AStarNode* prevNode = grid->getNode(prevCell);
+
+				if (stepDx > 0) {
+					prevNode->canGoRight = true;
+					if (isTwoWay)
+						node->canGoLeft = true;
+				}
+				else if (stepDx < 0) {
+					prevNode->canGoLeft = true;
+					if (isTwoWay)
+						node->canGoRight = true;
+				}
+				if (stepDy > 0) {
+					prevNode->canGoUp = true;
+					if (isTwoWay)
+						node->canGoDown = true;
+				}
+				else if (stepDy < 0) {
+					prevNode->canGoDown = true;
+					if (isTwoWay)
+						node->canGoUp = true;
+				}
+			}
+			prevCell = cell;
 
 			if (conditionRule) {
 				node->hasConditionalBarrier = true;
@@ -88,51 +113,6 @@ void PreferredPath::addPassagesToTable(Grid* grid)
 			}
 
 		});
-
-		if (!isTwoWay) {
-			for (const Cell& cell : segmentCells) {
-				AStarNode* node = grid->getNode(cell);
-				bool isEnd = cell.row == toRow && cell.col == toCol;
-
-				if (dx > 0 && !isEnd)
-					node->canGoRight = true;
-				if (dx < 0 && !isEnd)
-					node->canGoLeft = true;
-				if (dy > 0 && !isEnd)
-					node->canGoUp = true;
-				if (dy < 0 && !isEnd)
-					node->canGoDown = true;
-			}
-		}
-		else {
-			auto openPreferredPathStepDirections = [](AStarNode* node, int dCol, int dRow) {
-				if (dCol > 0)
-					node->canGoRight = true;
-				else if (dCol < 0)
-					node->canGoLeft = true;
-				if (dRow > 0)
-					node->canGoUp = true;
-				else if (dRow < 0)
-					node->canGoDown = true;
-				};
-
-			// Two-way: open only along the actual grid polyline (each step is one cell, axis-aligned).
-			// Mirroring segment dx/dy would set all four directions whenever both dx and dy are non-zero,
-			// incorrectly overriding walls next to the path (e.g. a full yellow "plus" on staircase cells).
-			for (size_t j = 0; j < segmentCells.size(); j++) {
-				AStarNode* node = grid->getNode(segmentCells[j]);
-				if (j + 1 < segmentCells.size()) {
-					int dCol = segmentCells[j + 1].col - segmentCells[j].col;
-					int dRow = segmentCells[j + 1].row - segmentCells[j].row;
-					openPreferredPathStepDirections(node, dCol, dRow);
-				}
-				if (j > 0) {
-					int dCol = segmentCells[j - 1].col - segmentCells[j].col;
-					int dRow = segmentCells[j - 1].row - segmentCells[j].row;
-					openPreferredPathStepDirections(node, dCol, dRow);
-				}
-			}
-		}
 	}
 }
 

--- a/AStarDLL/PreferredPath.cpp
+++ b/AStarDLL/PreferredPath.cpp
@@ -60,7 +60,7 @@ void PreferredPath::addPassagesToTable(Grid* grid)
 		int horizontalWeight = (int)(weight * 127 * dx / (fabs(dx) + fabs(dy)));
 		int verticalWeight = (int)(weight * 127 * dy / (fabs(dx) + fabs(dy)));
 
-		grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight, dx, dy, fromRow, fromCol, toRow, toCol](const Cell& cell) -> void {
+		grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight](const Cell& cell) -> void {
 			AStarNode* node = grid->getNode(cell);
 			AStarNodeExtraData * extra = grid->navigator->assertExtraData(cell, PreferredPathData);
 			node->hasPreferredPathWeight = true;
@@ -76,18 +76,6 @@ void PreferredPath::addPassagesToTable(Grid* grid)
 				extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + fabs(verticalWeight)));
 				extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown + fabs(verticalWeight)));
 			}
-
-			bool isStart = cell.row == fromRow && cell.col == fromCol;
-			bool isEnd = cell.row == toRow && cell.col == toCol;
-
-			if ((dx > 0 && !isEnd) || (isTwoWay && dx < 0 && !isStart))
-				node->canGoRight = true;
-			if ((dx < 0 && !isEnd) || (isTwoWay && dx > 0 && !isStart))
-				node->canGoLeft = true;
-			if ((dy > 0 && !isEnd) || (isTwoWay && dy < 0 && !isStart))
-				node->canGoUp = true;
-			if ((dy < 0 && !isEnd) || (isTwoWay && dy > 0 && !isStart))
-				node->canGoDown = true;			
 
 			if (conditionRule) {
 				node->hasConditionalBarrier = true;

--- a/AStarDLL/PreferredPath.cpp
+++ b/AStarDLL/PreferredPath.cpp
@@ -1,145 +1,95 @@
 #include "PreferredPath.h"
 #include "AStarNavigator.h"
-#include <vector>
 
 
 namespace AStar {
 
-	PreferredPath::PreferredPath()
-		: pathWeight(0.0)
-		, Divider()
-	{
-		return;
-	}
+PreferredPath::PreferredPath()
+	: pathWeight(0.0)
+	, Divider()
+{
+	return;
+}
 
-	PreferredPath::PreferredPath(double pathWeight)
-		: pathWeight(pathWeight)
-		, Divider()
-	{
-		return;
-	}
-
-
-	void PreferredPath::bindVariables(void)
-	{
-		__super::bindVariables();
-		bindVariable(pathWeight);
-	}
+PreferredPath::PreferredPath(double pathWeight)
+	: pathWeight(pathWeight)
+	, Divider()
+{
+	return;
+}
 
 
-	void PreferredPath::bind(void)
-	{
-		__super::bind();
-		bindCallback(getWeight, PreferredPath);
-		bindCallback(setWeight, PreferredPath);
-	}
+void PreferredPath::bindVariables(void)
+{
+	__super::bindVariables();
+	bindVariable(pathWeight);
+}
 
-	void PreferredPath::addPassagesToTable(Grid* grid)
-	{
-		double weight = pathWeight == 0 ? navigator->defaultPathWeight : pathWeight;
-		for (int i = 0; i < pointList.size() - 1; i++) {
 
-			Point* fromPoint = pointList[i];
-			Point* toPoint = pointList[i + 1];
-			Vec3 fromPos = fromPoint->project(holder, model());
-			Vec3 toPos = toPoint->project(holder, model());
+void PreferredPath::bind(void)
+{
+	__super::bind();
+	bindCallback(getWeight, PreferredPath);
+	bindCallback(setWeight, PreferredPath);
+}
 
-			// calculate the column and row numbers for that point
-			int fromCol = (int)round((fromPos.x - grid->gridOrigin.x) / nodeSize.x);
-			int fromRow = (int)round((fromPos.y - grid->gridOrigin.y) / nodeSize.y);
-			int toCol = (int)round((toPos.x - grid->gridOrigin.x) / nodeSize.x);
-			int toRow = (int)round((toPos.y - grid->gridOrigin.y) / nodeSize.y);
+void PreferredPath::addPassagesToTable(Grid* grid)
+{
+	double weight = pathWeight == 0 ? navigator->defaultPathWeight : pathWeight;
+	for (int i = 0; i < pointList.size() - 1; i++) {
+		
+		Point* fromPoint = pointList[i];
+		Point* toPoint = pointList[i + 1];
+		Vec3 fromPos = fromPoint->project(holder, model());
+		Vec3 toPos = toPoint->project(holder, model());
 
-			// set dx and dy, the differences between the rows and columns
-			double dx = toCol - fromCol;
-			double dy = toRow - fromRow;
+		// calculate the column and row numbers for that point
+		int fromCol = (int)round((fromPos.x - grid->gridOrigin.x) / nodeSize.x);
+		int fromRow = (int)round((fromPos.y - grid->gridOrigin.y) / nodeSize.y);
+		int toCol = (int)round((toPos.x - grid->gridOrigin.x) / nodeSize.x);
+		int toRow = (int)round((toPos.y - grid->gridOrigin.y) / nodeSize.y);
 
+		// set dx and dy, the differences between the rows and columns
+		double dx = toCol - fromCol;
+		double dy = toRow - fromRow;
+		
 		if(dy == 0 && dx == 0)
-				continue;
+			continue;
 
-			// calculate the weight values for preferred paths.
-			int horizontalWeight = (int)(weight * 127 * dx / (fabs(dx) + fabs(dy)));
-			int verticalWeight = (int)(weight * 127 * dy / (fabs(dx) + fabs(dy)));
+		// calculate the weight values for preferred paths.
+		int horizontalWeight = (int)(weight * 127 * dx / (fabs(dx) + fabs(dy)));
+		int verticalWeight = (int)(weight * 127 * dy / (fabs(dx) + fabs(dy)));
 
-			std::vector<Cell> segmentCells;
-			grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight, &segmentCells](const Cell& cell) -> void {
-				AStarNode* node = grid->getNode(cell);
-				AStarNodeExtraData* extra = grid->navigator->assertExtraData(cell, PreferredPathData);
-				node->hasPreferredPathWeight = true;
-
-				if (!isTwoWay) {
-					extra->bonusRight = (char)maxof(-128, minof(127, extra->bonusRight + horizontalWeight));
-					extra->bonusLeft = (char)maxof(-128, minof(127, extra->bonusLeft - horizontalWeight));
-					extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + verticalWeight));
-					extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown - verticalWeight));
-				}
-				else {
-					extra->bonusRight = (char)maxof(-128, minof(127, extra->bonusRight + fabs(horizontalWeight)));
-					extra->bonusLeft = (char)maxof(-128, minof(127, extra->bonusLeft + fabs(horizontalWeight)));
-					extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + fabs(verticalWeight)));
-					extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown + fabs(verticalWeight)));
-				}
-
-				segmentCells.push_back(cell);
-
-				if (conditionRule) {
-					node->hasConditionalBarrier = true;
-					extra->addConditionalBarrier(this);
-				}
-
-				});
+		grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight](const Cell& cell) -> void {
+			AStarNode* node = grid->getNode(cell);
+			AStarNodeExtraData * extra = grid->navigator->assertExtraData(cell, PreferredPathData);
+			node->hasPreferredPathWeight = true;
 
 			if (!isTwoWay) {
-				for (const Cell& cell : segmentCells) {
-					AStarNode* node = grid->getNode(cell);
-					bool isEnd = cell.row == toRow && cell.col == toCol;
-
-					if (dx > 0 && !isEnd)
-						node->canGoRight = true;
-					if (dx < 0 && !isEnd)
-						node->canGoLeft = true;
-					if (dy > 0 && !isEnd)
-						node->canGoUp = true;
-					if (dy < 0 && !isEnd)
-						node->canGoDown = true;
-				}
+				extra->bonusRight = (char)maxof(-128, minof(127, extra->bonusRight + horizontalWeight));
+				extra->bonusLeft = (char)maxof(-128, minof(127, extra->bonusLeft - horizontalWeight));
+				extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + verticalWeight));
+				extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown - verticalWeight));
+			} else {
+				extra->bonusRight = (char)maxof(-128, minof(127, extra->bonusRight + fabs(horizontalWeight)));
+				extra->bonusLeft = (char)maxof(-128, minof(127, extra->bonusLeft + fabs(horizontalWeight)));
+				extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + fabs(verticalWeight)));
+				extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown + fabs(verticalWeight)));
 			}
-			else {
-				auto openPreferredPathStepDirections = [](AStarNode* node, int dCol, int dRow) {
-					if (dCol > 0)
-						node->canGoRight = true;
-					else if (dCol < 0)
-						node->canGoLeft = true;
-					if (dRow > 0)
-						node->canGoUp = true;
-					else if (dRow < 0)
-						node->canGoDown = true;
-					};
 
-				// Two-way: open only along the actual grid polyline (each step is one cell, axis-aligned).
-				// Mirroring segment dx/dy would set all four directions whenever both dx and dy are non-zero,
-				// incorrectly overriding walls next to the path (e.g. a full yellow "plus" on staircase cells).
-				for (size_t j = 0; j < segmentCells.size(); j++) {
-					AStarNode* node = grid->getNode(segmentCells[j]);
-					if (j + 1 < segmentCells.size()) {
-						int dCol = segmentCells[j + 1].col - segmentCells[j].col;
-						int dRow = segmentCells[j + 1].row - segmentCells[j].row;
-						openPreferredPathStepDirections(node, dCol, dRow);
-					}
-					if (j > 0) {
-						int dCol = segmentCells[j - 1].col - segmentCells[j].col;
-						int dRow = segmentCells[j - 1].row - segmentCells[j].row;
-						openPreferredPathStepDirections(node, dCol, dRow);
-					}
-				}
+			if (conditionRule) {
+				node->hasConditionalBarrier = true;
+				extra->addConditionalBarrier(this);
 			}
-		}
-	}
 
-	void PreferredPath::addVertices(treenode view, Mesh* barrierMesh, float z, DrawStyle drawStyle)
-	{
-		addPathVertices(view, barrierMesh, z, Vec4f(0.0f, 1.0f, 0.0f, 1.0f), drawStyle, isTwoWay);
+		});
 	}
+}
+
+void PreferredPath::addVertices(treenode view, Mesh* barrierMesh, float z, DrawStyle drawStyle)
+{
+	addPathVertices(view, barrierMesh, z, Vec4f(0.0f, 1.0f, 0.0f, 1.0f), drawStyle, isTwoWay);
+}
 
 
 }

--- a/AStarDLL/PreferredPath.cpp
+++ b/AStarDLL/PreferredPath.cpp
@@ -1,95 +1,145 @@
 #include "PreferredPath.h"
 #include "AStarNavigator.h"
+#include <vector>
 
 
 namespace AStar {
 
-PreferredPath::PreferredPath()
-	: pathWeight(0.0)
-	, Divider()
-{
-	return;
-}
+	PreferredPath::PreferredPath()
+		: pathWeight(0.0)
+		, Divider()
+	{
+		return;
+	}
 
-PreferredPath::PreferredPath(double pathWeight)
-	: pathWeight(pathWeight)
-	, Divider()
-{
-	return;
-}
-
-
-void PreferredPath::bindVariables(void)
-{
-	__super::bindVariables();
-	bindVariable(pathWeight);
-}
+	PreferredPath::PreferredPath(double pathWeight)
+		: pathWeight(pathWeight)
+		, Divider()
+	{
+		return;
+	}
 
 
-void PreferredPath::bind(void)
-{
-	__super::bind();
-	bindCallback(getWeight, PreferredPath);
-	bindCallback(setWeight, PreferredPath);
-}
+	void PreferredPath::bindVariables(void)
+	{
+		__super::bindVariables();
+		bindVariable(pathWeight);
+	}
 
-void PreferredPath::addPassagesToTable(Grid* grid)
-{
-	double weight = pathWeight == 0 ? navigator->defaultPathWeight : pathWeight;
-	for (int i = 0; i < pointList.size() - 1; i++) {
-		
-		Point* fromPoint = pointList[i];
-		Point* toPoint = pointList[i + 1];
-		Vec3 fromPos = fromPoint->project(holder, model());
-		Vec3 toPos = toPoint->project(holder, model());
 
-		// calculate the column and row numbers for that point
-		int fromCol = (int)round((fromPos.x - grid->gridOrigin.x) / nodeSize.x);
-		int fromRow = (int)round((fromPos.y - grid->gridOrigin.y) / nodeSize.y);
-		int toCol = (int)round((toPos.x - grid->gridOrigin.x) / nodeSize.x);
-		int toRow = (int)round((toPos.y - grid->gridOrigin.y) / nodeSize.y);
+	void PreferredPath::bind(void)
+	{
+		__super::bind();
+		bindCallback(getWeight, PreferredPath);
+		bindCallback(setWeight, PreferredPath);
+	}
 
-		// set dx and dy, the differences between the rows and columns
-		double dx = toCol - fromCol;
-		double dy = toRow - fromRow;
-		
+	void PreferredPath::addPassagesToTable(Grid* grid)
+	{
+		double weight = pathWeight == 0 ? navigator->defaultPathWeight : pathWeight;
+		for (int i = 0; i < pointList.size() - 1; i++) {
+
+			Point* fromPoint = pointList[i];
+			Point* toPoint = pointList[i + 1];
+			Vec3 fromPos = fromPoint->project(holder, model());
+			Vec3 toPos = toPoint->project(holder, model());
+
+			// calculate the column and row numbers for that point
+			int fromCol = (int)round((fromPos.x - grid->gridOrigin.x) / nodeSize.x);
+			int fromRow = (int)round((fromPos.y - grid->gridOrigin.y) / nodeSize.y);
+			int toCol = (int)round((toPos.x - grid->gridOrigin.x) / nodeSize.x);
+			int toRow = (int)round((toPos.y - grid->gridOrigin.y) / nodeSize.y);
+
+			// set dx and dy, the differences between the rows and columns
+			double dx = toCol - fromCol;
+			double dy = toRow - fromRow;
+
 		if(dy == 0 && dx == 0)
-			continue;
+				continue;
 
-		// calculate the weight values for preferred paths.
-		int horizontalWeight = (int)(weight * 127 * dx / (fabs(dx) + fabs(dy)));
-		int verticalWeight = (int)(weight * 127 * dy / (fabs(dx) + fabs(dy)));
+			// calculate the weight values for preferred paths.
+			int horizontalWeight = (int)(weight * 127 * dx / (fabs(dx) + fabs(dy)));
+			int verticalWeight = (int)(weight * 127 * dy / (fabs(dx) + fabs(dy)));
 
-		grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight](const Cell& cell) -> void {
-			AStarNode* node = grid->getNode(cell);
-			AStarNodeExtraData * extra = grid->navigator->assertExtraData(cell, PreferredPathData);
-			node->hasPreferredPathWeight = true;
+			std::vector<Cell> segmentCells;
+			grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight, &segmentCells](const Cell& cell) -> void {
+				AStarNode* node = grid->getNode(cell);
+				AStarNodeExtraData* extra = grid->navigator->assertExtraData(cell, PreferredPathData);
+				node->hasPreferredPathWeight = true;
+
+				if (!isTwoWay) {
+					extra->bonusRight = (char)maxof(-128, minof(127, extra->bonusRight + horizontalWeight));
+					extra->bonusLeft = (char)maxof(-128, minof(127, extra->bonusLeft - horizontalWeight));
+					extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + verticalWeight));
+					extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown - verticalWeight));
+				}
+				else {
+					extra->bonusRight = (char)maxof(-128, minof(127, extra->bonusRight + fabs(horizontalWeight)));
+					extra->bonusLeft = (char)maxof(-128, minof(127, extra->bonusLeft + fabs(horizontalWeight)));
+					extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + fabs(verticalWeight)));
+					extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown + fabs(verticalWeight)));
+				}
+
+				segmentCells.push_back(cell);
+
+				if (conditionRule) {
+					node->hasConditionalBarrier = true;
+					extra->addConditionalBarrier(this);
+				}
+
+				});
 
 			if (!isTwoWay) {
-				extra->bonusRight = (char)maxof(-128, minof(127, extra->bonusRight + horizontalWeight));
-				extra->bonusLeft = (char)maxof(-128, minof(127, extra->bonusLeft - horizontalWeight));
-				extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + verticalWeight));
-				extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown - verticalWeight));
-			} else {
-				extra->bonusRight = (char)maxof(-128, minof(127, extra->bonusRight + fabs(horizontalWeight)));
-				extra->bonusLeft = (char)maxof(-128, minof(127, extra->bonusLeft + fabs(horizontalWeight)));
-				extra->bonusUp = (char)maxof(-128, minof(127, extra->bonusUp + fabs(verticalWeight)));
-				extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown + fabs(verticalWeight)));
-			}
+				for (const Cell& cell : segmentCells) {
+					AStarNode* node = grid->getNode(cell);
+					bool isEnd = cell.row == toRow && cell.col == toCol;
 
-			if (conditionRule) {
-				node->hasConditionalBarrier = true;
-				extra->addConditionalBarrier(this);
+					if (dx > 0 && !isEnd)
+						node->canGoRight = true;
+					if (dx < 0 && !isEnd)
+						node->canGoLeft = true;
+					if (dy > 0 && !isEnd)
+						node->canGoUp = true;
+					if (dy < 0 && !isEnd)
+						node->canGoDown = true;
+				}
 			}
+			else {
+				auto openPreferredPathStepDirections = [](AStarNode* node, int dCol, int dRow) {
+					if (dCol > 0)
+						node->canGoRight = true;
+					else if (dCol < 0)
+						node->canGoLeft = true;
+					if (dRow > 0)
+						node->canGoUp = true;
+					else if (dRow < 0)
+						node->canGoDown = true;
+					};
 
-		});
+				// Two-way: open only along the actual grid polyline (each step is one cell, axis-aligned).
+				// Mirroring segment dx/dy would set all four directions whenever both dx and dy are non-zero,
+				// incorrectly overriding walls next to the path (e.g. a full yellow "plus" on staircase cells).
+				for (size_t j = 0; j < segmentCells.size(); j++) {
+					AStarNode* node = grid->getNode(segmentCells[j]);
+					if (j + 1 < segmentCells.size()) {
+						int dCol = segmentCells[j + 1].col - segmentCells[j].col;
+						int dRow = segmentCells[j + 1].row - segmentCells[j].row;
+						openPreferredPathStepDirections(node, dCol, dRow);
+					}
+					if (j > 0) {
+						int dCol = segmentCells[j - 1].col - segmentCells[j].col;
+						int dRow = segmentCells[j - 1].row - segmentCells[j].row;
+						openPreferredPathStepDirections(node, dCol, dRow);
+					}
+				}
+			}
+		}
 	}
-}
 
-void PreferredPath::addVertices(treenode view, Mesh* barrierMesh, float z, DrawStyle drawStyle)
-{
-	addPathVertices(view, barrierMesh, z, Vec4f(0.0f, 1.0f, 0.0f, 1.0f), drawStyle, isTwoWay);
-}
+	void PreferredPath::addVertices(treenode view, Mesh* barrierMesh, float z, DrawStyle drawStyle)
+	{
+		addPathVertices(view, barrierMesh, z, Vec4f(0.0f, 1.0f, 0.0f, 1.0f), drawStyle, isTwoWay);
+	}
 
 
 }

--- a/AStarDLL/PreferredPath.cpp
+++ b/AStarDLL/PreferredPath.cpp
@@ -1,6 +1,5 @@
 #include "PreferredPath.h"
 #include "AStarNavigator.h"
-#include <vector>
 
 
 namespace AStar {

--- a/AStarDLL/PreferredPath.cpp
+++ b/AStarDLL/PreferredPath.cpp
@@ -1,5 +1,6 @@
 #include "PreferredPath.h"
 #include "AStarNavigator.h"
+#include <vector>
 
 
 namespace AStar {
@@ -60,7 +61,9 @@ void PreferredPath::addPassagesToTable(Grid* grid)
 		int horizontalWeight = (int)(weight * 127 * dx / (fabs(dx) + fabs(dy)));
 		int verticalWeight = (int)(weight * 127 * dy / (fabs(dx) + fabs(dy)));
 
-		grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight](const Cell& cell) -> void {
+		std::vector<Cell> segmentCells;
+
+		grid->visitGridModelLine(fromPos, toPos, [this, grid, horizontalWeight, verticalWeight, &segmentCells](const Cell& cell) -> void {
 			AStarNode* node = grid->getNode(cell);
 			AStarNodeExtraData * extra = grid->navigator->assertExtraData(cell, PreferredPathData);
 			node->hasPreferredPathWeight = true;
@@ -77,12 +80,59 @@ void PreferredPath::addPassagesToTable(Grid* grid)
 				extra->bonusDown = (char)maxof(-128, minof(127, extra->bonusDown + fabs(verticalWeight)));
 			}
 
+			segmentCells.push_back(cell);
+
 			if (conditionRule) {
 				node->hasConditionalBarrier = true;
 				extra->addConditionalBarrier(this);
 			}
 
 		});
+
+		if (!isTwoWay) {
+			for (const Cell& cell : segmentCells) {
+				AStarNode* node = grid->getNode(cell);
+				bool isEnd = cell.row == toRow && cell.col == toCol;
+
+				if (dx > 0 && !isEnd)
+					node->canGoRight = true;
+				if (dx < 0 && !isEnd)
+					node->canGoLeft = true;
+				if (dy > 0 && !isEnd)
+					node->canGoUp = true;
+				if (dy < 0 && !isEnd)
+					node->canGoDown = true;
+			}
+		}
+		else {
+			auto openPreferredPathStepDirections = [](AStarNode* node, int dCol, int dRow) {
+				if (dCol > 0)
+					node->canGoRight = true;
+				else if (dCol < 0)
+					node->canGoLeft = true;
+				if (dRow > 0)
+					node->canGoUp = true;
+				else if (dRow < 0)
+					node->canGoDown = true;
+				};
+
+			// Two-way: open only along the actual grid polyline (each step is one cell, axis-aligned).
+			// Mirroring segment dx/dy would set all four directions whenever both dx and dy are non-zero,
+			// incorrectly overriding walls next to the path (e.g. a full yellow "plus" on staircase cells).
+			for (size_t j = 0; j < segmentCells.size(); j++) {
+				AStarNode* node = grid->getNode(segmentCells[j]);
+				if (j + 1 < segmentCells.size()) {
+					int dCol = segmentCells[j + 1].col - segmentCells[j].col;
+					int dRow = segmentCells[j + 1].row - segmentCells[j].row;
+					openPreferredPathStepDirections(node, dCol, dRow);
+				}
+				if (j > 0) {
+					int dCol = segmentCells[j - 1].col - segmentCells[j].col;
+					int dRow = segmentCells[j - 1].row - segmentCells[j].row;
+					openPreferredPathStepDirections(node, dCol, dRow);
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This pull request refactors the logic for setting node direction flags in the `PreferredPath::addPassagesToTable` method to improve correctness and maintainability, especially for two-way preferred paths. The update introduces a `segmentCells` vector to collect all cells along a path segment, and then processes these cells after the grid line visit to set `canGo*` flags more accurately, preventing incorrect direction openings (especially at corners or when handling two-way paths).

Key changes:

**Direction flag logic refactor:**

* Introduced a `segmentCells` vector to collect all cells along the path segment during `visitGridModelLine`, deferring the setting of `canGo*` flags until after all cells are collected. This allows for more precise control over which directions are opened for each node.
* For one-way paths, direction flags (`canGoRight`, `canGoLeft`, `canGoUp`, `canGoDown`) are set for each cell in the segment except the end cell, based on the overall direction of the segment.
* For two-way paths, direction flags are set only along the actual polyline steps between adjacent cells, preventing the erroneous opening of all four directions at corners. This is achieved by comparing each cell with its neighbors and setting directions accordingly.

**Code structure improvements:**

* Added the `#include <vector>` directive to support the use of `std::vector` for segment cell collection.
* Encapsulated the logic for opening direction flags in a lambda (`openPreferredPathStepDirections`) for clarity and reuse in the two-way path handling.

Fixes : A*Star grid bug with twoway preferred paths [FLEXSIM-12564](https://jira.autodesk.com/browse/FLEXSIM-12564)