### PR TITLE
[FLEXSIM-6721] Fix Path Point Table Values Updating

### DIFF
--- a/AStar.fsx
+++ b/AStar.fsx
@@ -3407,8 +3407,12 @@ if (!eventdata) {
 		repaintall();
 	}	
 }</data></node>
-           <node f="42" dt="2"><name>OnKeyUp</name><data>#define VK_RETURN 13
-if (lastkeydown() == VK_RETURN) {
+           <node f="42" dt="2"><name>OnKeyUp</name><data>#define VK_RETURN	0x0D
+#define VK_TAB		0x09
+
+if (lastkeydown() == VK_RETURN ||
+	lastkeydown() == VK_TAB ||
+	directionkeypressed()) {
 	applylinks(c);
 }</data></node>
            <node f="42" dt="2"><name>OnClick</name><data>if (clickcode() == LEFT_RELEASE) {
@@ -3436,6 +3440,7 @@ if (lastkeydown() == VK_RETURN) {
 </data></node>
            <node f="42" dt="2"><name>OnFocus</name><data>if (!objectexists(i) || i != c)
 	applylinks(c, 1);</data></node>
+           <node f="42" dt="2"><name>OnKillFocus</name><data>applylinks(c);</data></node>
            <node f="42" dt="2"><name>OnMouseWheel</name><data>treenode TheTable = ownerobject(c);
 
 double vert_nMin = scrollinfo(TheTable,0,1,1);
@@ -6281,8 +6286,12 @@ if (!eventdata) {
 		repaintall();
 	}	
 }</data></node>
-         <node f="42" dt="2"><name>OnKeyUp</name><data>#define VK_RETURN 13
-if (lastkeydown() == VK_RETURN) {
+         <node f="42" dt="2"><name>OnKeyUp</name><data>#define VK_RETURN	0x0D
+#define VK_TAB		0x09
+
+if (lastkeydown() == VK_RETURN ||
+	lastkeydown() == VK_TAB ||
+	directionkeypressed()) {
 	applylinks(c);
 }</data></node>
          <node f="42" dt="2"><name>OnClick</name><data>if (clickcode() == LEFT_RELEASE) {
@@ -6310,6 +6319,7 @@ if (lastkeydown() == VK_RETURN) {
 </data></node>
          <node f="42" dt="2"><name>OnFocus</name><data>if (!objectexists(i) || i != c)
 	applylinks(c, 1);</data></node>
+         <node f="42" dt="2"><name>OnKillFocus</name><data>applylinks(c);</data></node>
          <node f="42" dt="2"><name>OnMouseWheel</name><data>treenode TheTable = ownerobject(c);
 
 double vert_nMin = scrollinfo(TheTable,0,1,1);


### PR DESCRIPTION
* There were several keys not being identified when navigating the points table. They were specifically: Tab, Left, Up, Right, and Down. I added them as things to check.
* Also added OnKillFocus so if a user clicks out of the table, the cell gets applied.
* Updated VK_RETURN to be in hexidecimal (similar to pattern in other places throughout the code).
* This is in relation to [a PR](https://github.com/flexsim-adsk/flexsim/pull/254) in the FlexSim repo.